### PR TITLE
adapt for dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules
 .DS_STORE
 /.settings
 /.project
-config/database.js
 .env

--- a/config/database.js
+++ b/config/database.js
@@ -1,0 +1,17 @@
+module.exports = {
+
+    // If you need to use a local databse comment out the mlab line. If you want to use mlab comment out the localhost mongodb.
+
+    // Mlab database
+     //database: 'mongodb://admin1:admin1@ds161574.mlab.com:61574/coderef',
+
+    // local database
+    database: process.env.MONGO_URI || 'mongodb://localhost:27017/meanauth',
+    secret: process.env.SECRET || 'yoursecret',
+
+
+
+
+
+
+}


### PR DESCRIPTION
This adds back `config/database.js` but defaults to local if you do not have the environment variable defined. 